### PR TITLE
New URL & fix for Sirius dependencies

### DIFF
--- a/de.uni_stuttgart.iste.cowolf.core.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.core.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Core feature, which provides the main components of CoWolf. It also includes Logging.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.core/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.core/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Core feature, which provides the main components of CoWolf. It also includes Logging.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.evolution.activity_diagram.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.evolution.activity_diagram.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Activity Diagram Evolution feature, which enables the Activity Diagram Evolution functionality for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.evolution.activity_diagram/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.evolution.activity_diagram/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Activity Diagram Evolution feature, which enables the Activity Diagram Evolution functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.evolution.component_diagram.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.evolution.component_diagram.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Component Diagram Evolution feature, which enables the
 Component Diagram Evolution functionality for CoWolf.
    </description>

--- a/de.uni_stuttgart.iste.cowolf.evolution.component_diagram/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.evolution.component_diagram/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Component Diagram Evolution feature, which enables the Component Diagram Evolution functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.evolution.ctmc.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.evolution.ctmc.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf CTMC Evolution feature, which enables the CTMC Evolution functionality for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.evolution.ctmc/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.evolution.ctmc/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf CTMC Evolution feature, which enables the CTMC Evolution functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.evolution.dtmc.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.evolution.dtmc.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf DTMC Evolution feature, which enables the DTMC Evolution functionality for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.evolution.dtmc/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.evolution.dtmc/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf DTMC Evolution feature, which enables the DTMC Evolution functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.evolution.fault_tree.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.evolution.fault_tree.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Fault Tree Evolution feature, which enables the Fault Tree Evolution functionality for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.evolution.fault_tree/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.evolution.fault_tree/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Fault Tree Evolution feature, which enables the Fault Tree Evolution functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.evolution.lqn.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.evolution.lqn.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf LQN Evolution feature, which enables the LQN Evolution functionality for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.evolution.lqn/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.evolution.lqn/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf LQN Evolution feature, which enables the LQN Evolution functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.evolution.sequence_diagram.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.evolution.sequence_diagram.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Sequence Diagram Evolution feature, which enables the
 Sequence Diagram Evolution functionality for CoWolf.
    </description>

--- a/de.uni_stuttgart.iste.cowolf.evolution.sequence_diagram/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.evolution.sequence_diagram/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Sequence Diagram Evolution feature, which enables the Sequence Diagram Evolution functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.evolution.statechart.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.evolution.statechart.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Statechart Evolution feature, which enables the Statechart Evolution functionality for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.evolution.statechart/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.evolution.statechart/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Statechart Evolution feature, which enables the Statechart Evolution functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.evolution/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.evolution/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Evolution feature, which enables the evolution functionality of CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf allows you to create architecture models and multiple QoS models of the same system. It also allows you to develop transformations between the models to help the evolution. Moreover CoWolf supports you keeping multiple models consistent whenever they evolve. CoWolf also integrates verification frameworks for QoS models.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.license.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.license.feature/feature.xml
@@ -5,7 +5,7 @@
       version="1.0.0.qualifier"
       provider-name="University of Stuttgart Institute of Software Technology">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf License Agreement
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.model.activity_diagram.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.model.activity_diagram.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Activity Diagram feature, which provides the Activity Diagram model for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.model.activity_diagram/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.model.activity_diagram/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Activity Diagram feature, which provides the Activity Diagram model for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.model.component_diagram.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.model.component_diagram.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Component Diagram feature, which provides the Component Diagram model for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.model.component_diagram.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.model.component_diagram.feature/feature.xml
@@ -29,8 +29,8 @@ This program and the accompanying materials are made available under the terms o
       <import plugin="org.eclipse.sirius.ui"/>
       <import plugin="org.eclipse.emf.transaction"/>
       <import plugin="org.eclipse.ui"/>
-      <import plugin="org.eclipse.sirius" version="1.0.0" match="compatible"/>
-      <import plugin="org.eclipse.uml2.uml" version="5.0.0" match="compatible"/>
+      <import plugin="org.eclipse.sirius" version="1.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.uml2.uml" version="5.0.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.uml2.uml.edit"/>
       <import plugin="org.eclipse.sirius.common"/>
       <import plugin="org.eclipse.sirius.common.ui"/>

--- a/de.uni_stuttgart.iste.cowolf.model.component_diagram.sirius.editor/META-INF/MANIFEST.MF
+++ b/de.uni_stuttgart.iste.cowolf.model.component_diagram.sirius.editor/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: de.uni_stuttgart.iste.cowolf.model.component_diagram.sirius
 Bundle-Version: 1.0.0.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.sirius;bundle-version="[1.0.0,2.0.0)",
+ org.eclipse.sirius;bundle-version="[1.0.0,3.0.0)",
  org.eclipse.uml2.uml;bundle-version="[5.0.0,6.0.0)",
  org.eclipse.uml2.uml.edit,
  org.eclipse.sirius.common,

--- a/de.uni_stuttgart.iste.cowolf.model.component_diagram/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.model.component_diagram/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Component Diagram feature, which provides the Component Diagram model for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.model.ctmc.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.model.ctmc.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf CTMC feature, which provides the CTMC model for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.model.ctmc/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.model.ctmc/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf CTMC feature, which provides the CTMC model for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.model.dtmc.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.model.dtmc.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf DTMC feature, which provides the DTMC model for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.model.dtmc/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.model.dtmc/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf DTMC feature, which provides the DTMC model for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.model.fault_tree.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.model.fault_tree.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Fault Tree feature, which provides the Fault Tree model for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.model.fault_tree/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.model.fault_tree/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Fault Tree feature, which provides the Fault Tree model for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.model.lqn.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.model.lqn.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf LQN feature, which provides the LQN model for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.model.lqn/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.model.lqn/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf LQN feature, which provides the LQN model for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.model.sequence_diagram.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.model.sequence_diagram.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Sequence Diagram feature, which provides the Sequence
 Diagram model for CoWolf.
    </description>

--- a/de.uni_stuttgart.iste.cowolf.model.sequence_diagram.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.model.sequence_diagram.feature/feature.xml
@@ -21,8 +21,8 @@ This program and the accompanying materials are made available under the terms o
    <requires>
       <import plugin="org.eclipse.ui"/>
       <import plugin="org.eclipse.core.runtime"/>
-      <import plugin="org.eclipse.sirius" version="1.0.0" match="compatible"/>
-      <import plugin="org.eclipse.uml2.uml" version="5.0.0" match="compatible"/>
+      <import plugin="org.eclipse.sirius" version="1.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.uml2.uml" version="5.0.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.uml2.uml.edit"/>
       <import plugin="org.eclipse.sirius.common"/>
       <import plugin="org.eclipse.sirius.common.ui"/>

--- a/de.uni_stuttgart.iste.cowolf.model.sequence_diagram.sirius.editor/META-INF/MANIFEST.MF
+++ b/de.uni_stuttgart.iste.cowolf.model.sequence_diagram.sirius.editor/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: de.uni_stuttgart.iste.cowolf.model.sequence_diagram.sirius.editor.design.UMLDesignerPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.sirius;bundle-version="[1.0.0,2.0.0)",
+ org.eclipse.sirius;bundle-version="[1.0.0,3.0.0)",
  org.eclipse.uml2.uml;bundle-version="[5.0.0,6.0.0)",
  org.eclipse.uml2.uml.edit,
  org.eclipse.sirius.common,

--- a/de.uni_stuttgart.iste.cowolf.model.sequence_diagram/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.model.sequence_diagram/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Sequence Diagram feature, which provides the Sequence Diagram model for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.model.statechart.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.model.statechart.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Statechart feature, which provides the Statechart model for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.model.statechart/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.model.statechart/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Statechart feature, which provides the Statechart model for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.model/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.model/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Model feature, which provides the supported models of CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.parent/pom.xml
+++ b/de.uni_stuttgart.iste.cowolf.parent/pom.xml
@@ -26,7 +26,7 @@
 		</repository>
 		<repository>
 			<id>silift</id>
-			<url>http://devprojectss2014.github.io/CoWolf/SiliftUpdateSite/</url>
+			<url>http://cowolf.github.io/SiliftUpdateSite/</url>
 			<layout>p2</layout>
 		</repository>
 		<repository>
@@ -36,7 +36,7 @@
 		</repository>
 		<repository>
 			<id>dependencies</id>
-			<url>http://devprojectss2014.github.io/CoWolf/DependenciesUpdateSite</url>
+			<url>http://cowolf.github.io/DependenciesUpdateSite</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>

--- a/de.uni_stuttgart.iste.cowolf.skeleton.branding/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.skeleton.branding/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Skeleton feature, which provides skeletons for developer to implement further plugins for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.skeleton.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.skeleton.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Skeleton feature, which provides skeletons for developer to implement further plugins for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.transformation.component_diagram_fault_tree.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.transformation.component_diagram_fault_tree.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Transformation Component Diagram to Fault Tree feature, which enables the Component Diagram to Fault Tree Transformation (one direction) functionality for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.transformation.component_diagram_fault_tree/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.transformation.component_diagram_fault_tree/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Transformation Component Diagram to Fault Tree feature, which enables the Component Diagram to Fault Tree Transformation (one direction) functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.transformation.dtmc_ctmc.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.transformation.dtmc_ctmc.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Transformation DTMC / CTMC feature, which enables the
 DTMC / CTMC Transformation (both directions) functionality for
 CoWolf.

--- a/de.uni_stuttgart.iste.cowolf.transformation.dtmc_ctmc/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.transformation.dtmc_ctmc/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Transformation DTMC / CTMC feature, which enables the DTMC / CTMC Transformation (both directions) functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.transformation.dtmc_statechart.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.transformation.dtmc_statechart.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Transformation DTMC / Statechart feature, which enables
 the DTMC / Statechart Transformation (both directions) functionality
 for CoWolf.

--- a/de.uni_stuttgart.iste.cowolf.transformation.dtmc_statechart/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.transformation.dtmc_statechart/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Transformation DTMC / Statechart feature, which enables the DTMC / Statechart Transformation (both directions) functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.transformation.faulttree_ctmc.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.transformation.faulttree_ctmc.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Transformation Fault Tree to CTMC feature, which enables the Fault Tree to CTMC Transformation (one direction) functionality for CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.transformation.faulttree_ctmc/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.transformation.faulttree_ctmc/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Transformation Fault Tree to CTMC feature, which enables the Fault Tree to CTMC Transformation (one direction) functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.transformation.generator.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.transformation.generator.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Transformation Mapping Editor feature that contains an editor for creating Transformation Mapping files which maps SiLift recognition rules on Henshin transformation rules.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.transformation.sequencediagram_lqn.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.transformation.sequencediagram_lqn.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf Transformation Sequence Diagram to LQN feature, which
 enables the Sequence Diagram to LQN Transformation (one direction)
 functionality for CoWolf.

--- a/de.uni_stuttgart.iste.cowolf.transformation.sequencediagram_lqn/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.transformation.sequencediagram_lqn/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Transformation Sequence Diagram to LQN feature, which enables the Sequence Diagram to LQN Transformation (one direction) functionality for CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.transformation/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.transformation/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf Transformation feature, which enables the transformation functionality of CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf.ui.feature/feature.xml
+++ b/de.uni_stuttgart.iste.cowolf.ui.feature/feature.xml
@@ -8,7 +8,7 @@
       license-feature="de.uni_stuttgart.iste.cowolf.license.feature"
       license-feature-version="1.0.0.qualifier">
 
-   <description url="http://devprojectss2014.github.io/CoWolf/">
+   <description url="http://cowolf.github.io/">
       CoWolf UI feature, which provides the general UI components of CoWolf.
    </description>
 

--- a/de.uni_stuttgart.iste.cowolf.ui/about.ini
+++ b/de.uni_stuttgart.iste.cowolf.ui/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf UI feature, which provides the general UI components of CoWolf.\n\
-Visit http://devprojectss2014.github.io/CoWolf/ for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf/about.ini
+++ b/de.uni_stuttgart.iste.cowolf/about.ini
@@ -1,3 +1,3 @@
 featureImage=cowolf.png
 aboutText=CoWolf allows you to create architecture models and multiple QoS models of the same system. It also allows you to develop transformations between the models to help the evolution. Moreover CoWolf supports you keeping multiple models consistent whenever they evolve. CoWolf also integrates verification frameworks for QoS models.\n\
-Visit http://devprojectss2014.github.io/CoWolf for more information.
+Visit http://cowolf.github.io/ for more information.

--- a/de.uni_stuttgart.iste.cowolf/plugin.xml
+++ b/de.uni_stuttgart.iste.cowolf/plugin.xml
@@ -29,7 +29,7 @@
          </property>
          <property
                name="aboutText"
-               value="CoWolf&#x0A;Version: 1.0.0&#x0A;&#x0A;http://devprojectss2014.github.io/CoWolf&#x0A;&#x0A;Copyright (c) 2014 CoWolf contributors. All rights reserved. &#x0A;This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.&#x0A;&#x0A;*** Contributors ***&#x0A;Christian Karl Bernasko, Manuel Borja, Verena Käfer, David Krauss, Michael Müller, Philipp Niethammer, Tim Sanwald, Jonas Scheurich, David Steinhart, Rene Trefft, Johannes Wolf, Michael Zimmermann">
+               value="CoWolf&#x0A;Version: 1.0.0&#x0A;&#x0A;http://cowolf.github.io/&#x0A;&#x0A;Copyright (c) 2014 CoWolf contributors. All rights reserved. &#x0A;This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.&#x0A;&#x0A;*** Contributors ***&#x0A;Christian Karl Bernasko, Manuel Borja, Verena Käfer, David Krauss, Michael Müller, Philipp Niethammer, Tim Sanwald, Jonas Scheurich, David Steinhart, Rene Trefft, Johannes Wolf, Michael Zimmermann">
          </property>
          <property
                name="windowImages"


### PR DESCRIPTION
The old URL is no longer available. This leads to errors for the Maven-dependencies. Also it's not userfriendly to reference a dead link ;)

Sirius is available in 3.0.0 and default marketplace version is 2.0.0 - therefore "compatible" is not enough as the major version must be the same.
